### PR TITLE
Populate title based on @ApiModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Optionally provide a field/method's "title" as per `@ApiModel(value = ...)`
+- Allow to ignore the general `@ApiModel(description = ...)` when populating a field/method's "description"
 
 ## [3.0.0] – 2019-06-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ Module for the `jsonschema-generator` – deriving JSON Schema attributes from `
 ## Features
 1. Optionally override a field's property name with `@ApiModelProperty(name = ...)`
 2. Optionally ignore a field/method if `@ApiModelProperty(hidden = true)`
-3. Provide a field/method's "description" as per `@ApiModelProperty(value = ...)` or `@ApiModel(description = ...)`
-4. Indicate a number's (field/method) "minimum" (inclusive) according to `@ApiModelProperty(allowableValues = "range[...")`
-5. Indicate a number's (field/method) "exclusiveMinimum" according to `@ApiModelProperty(allowableValues = "range(...")`
-6. Indicate a number's (field/method) "maximum" (inclusive) according to `@ApiModelProperty(allowableValues = "range...]")`
-7. Indicate a number's (field/method) "exclusiveMaximum" according to `@ApiModelProperty(allowableValues = "range...)")`
-8. Indicate a field/method's "const"/"enum" as `@ApiModelProperty(allowableValues = ...)` (if it is not a numeric range declaration)
+3. Optionally provide a field/method's "title" as per `@ApiModel(value = ...)`
+4. Provide a field/method's "description" as per `@ApiModelProperty(value = ...)` or (optionally) `@ApiModel(description = ...)`
+5. Indicate a number's (field/method) "minimum" (inclusive) according to `@ApiModelProperty(allowableValues = "range[...")`
+6. Indicate a number's (field/method) "exclusiveMinimum" according to `@ApiModelProperty(allowableValues = "range(...")`
+7. Indicate a number's (field/method) "maximum" (inclusive) according to `@ApiModelProperty(allowableValues = "range...]")`
+8. Indicate a number's (field/method) "exclusiveMaximum" according to `@ApiModelProperty(allowableValues = "range...)")`
+9. Indicate a field/method's "const"/"enum" as `@ApiModelProperty(allowableValues = ...)` (if it is not a numeric range declaration)
 
 Schema attributes derived from `@ApiModelProperty` on fields are also applied to their respective getter methods.
 Schema attributes derived from `@ApiModelProperty` on getter methods are also applied to their associated fields.

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
     </issueManagement>
 
     <scm>
-        <connection>scm:git:ssh://github.com/victools/jsonschema-module-swagger-1.5.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/victools/jsonschema-module-swagger-1.5.git</developerConnection>
+        <connection>scm:git:https://github.com/victools/jsonschema-module-swagger-1.5.git</connection>
+        <developerConnection>scm:git:https://github.com/victools/jsonschema-module-swagger-1.5.git</developerConnection>
         <url>https://github.com/victools/jsonschema-module-swagger-1.5</url>
         <tag>HEAD</tag>
     </scm>
@@ -58,7 +58,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <version.generator>3.0.0</version.generator>
+        <version.generator>3.4.0</version.generator>
 
         <version.swagger>1.5.22</version.swagger>
         <version.junit>4.12</version.junit>

--- a/src/main/java/com/github/victools/jsonschema/module/swagger15/SwaggerOption.java
+++ b/src/main/java/com/github/victools/jsonschema/module/swagger15/SwaggerOption.java
@@ -27,5 +27,13 @@ public enum SwaggerOption {
     /**
      * Use this option to apply alternative property names specified via {@code @ApiModelProperty(name = "...")}.
      */
-    ENABLE_PROPERTY_NAME_OVERRIDES;
+    ENABLE_PROPERTY_NAME_OVERRIDES,
+    /**
+     * Use this option to NOT set the "description" property (based on {@code @ApiModel(description = "...")}).
+     */
+    NO_APIMODEL_DESCRIPTION,
+    /**
+     * Use this option to NOT set the "title" property (based on {@code @ApiModel(value = "...")}).
+     */
+    NO_APIMODEL_TITLE;
 }

--- a/src/test/java/com/github/victools/jsonschema/module/swagger15/SwaggerModuleTest.java
+++ b/src/test/java/com/github/victools/jsonschema/module/swagger15/SwaggerModuleTest.java
@@ -59,12 +59,16 @@ public class SwaggerModuleTest {
 
         this.verifyCommonConfigurations();
 
+        Mockito.verify(this.fieldConfigPart).withTitleResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withTitleResolver(Mockito.any());
+
         Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart);
     }
 
     @Test
     public void testApplyToConfigBuilderWithAllOptions() {
-        new SwaggerModule(SwaggerOption.ENABLE_PROPERTY_NAME_OVERRIDES, SwaggerOption.IGNORING_HIDDEN_PROPERTIES)
+        new SwaggerModule(SwaggerOption.ENABLE_PROPERTY_NAME_OVERRIDES, SwaggerOption.IGNORING_HIDDEN_PROPERTIES,
+                SwaggerOption.NO_APIMODEL_DESCRIPTION, SwaggerOption.NO_APIMODEL_TITLE)
                 .applyToConfigBuilder(this.configBuilder);
 
         this.verifyCommonConfigurations();
@@ -84,7 +88,10 @@ public class SwaggerModuleTest {
 
         this.verifyCommonConfigurations();
 
+        Mockito.verify(this.fieldConfigPart).withTitleResolver(Mockito.any());
         Mockito.verify(this.fieldConfigPart).withPropertyNameOverrideResolver(Mockito.any());
+
+        Mockito.verify(this.methodConfigPart).withTitleResolver(Mockito.any());
 
         Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart);
     }
@@ -96,8 +103,21 @@ public class SwaggerModuleTest {
 
         this.verifyCommonConfigurations();
 
+        Mockito.verify(this.fieldConfigPart).withTitleResolver(Mockito.any());
         Mockito.verify(this.fieldConfigPart).withIgnoreCheck(Mockito.any());
+
+        Mockito.verify(this.methodConfigPart).withTitleResolver(Mockito.any());
         Mockito.verify(this.methodConfigPart).withIgnoreCheck(Mockito.any());
+
+        Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart);
+    }
+
+    @Test
+    public void testApplyToConfigBuilderWithoutApiModelTitle() {
+        new SwaggerModule(SwaggerOption.NO_APIMODEL_TITLE)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.verifyCommonConfigurations();
 
         Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart);
     }

--- a/src/test/java/com/github/victools/jsonschema/module/swagger15/SwaggerModuleTest.java
+++ b/src/test/java/com/github/victools/jsonschema/module/swagger15/SwaggerModuleTest.java
@@ -21,6 +21,7 @@ import com.github.victools.jsonschema.generator.FieldScope;
 import com.github.victools.jsonschema.generator.MethodScope;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigPart;
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -191,13 +192,39 @@ public class SwaggerModuleTest {
         Assert.assertEquals(expectedNameOverride, override);
     }
 
+    Object parametersForTestTitleResolver() {
+        return new Object[][]{
+            {"unannotatedField", null},
+            {"exampleWithEmptyApiModel", null},
+            {"exampleWithApiModelTitle", "example title"}
+        };
+    }
+
+    @Test
+    @Parameters
+    public void testTitleResolver(String fieldName, String expectedTitle) {
+        new SwaggerModule().applyToConfigBuilder(this.configBuilder);
+
+        TestType testType = new TestType(TestClassForDescription.class);
+        FieldScope field = testType.getMemberField(fieldName);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, String>> captor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withTitleResolver(captor.capture());
+        String title = captor.getValue().apply(field);
+        Assert.assertEquals(expectedTitle, title);
+    }
+
     Object parametersForTestDescriptionResolver() {
         return new Object[][]{
             {"unannotatedField", null},
             {"annotatedWithoutValueField", null},
             {"annotatedWithoutValueGetterField", null},
             {"annotatedField", "annotation value 1"},
-            {"annotatedGetterField", "annotation value 2"}
+            {"annotatedGetterField", "annotation value 2"},
+            {"exampleWithEmptyApiModel", null},
+            {"exampleWithApiModelDescription", "type description"},
+            {"exampleWithTwoDescriptions", "property description"},
+            {"exampleWithApiModelTitle", null}
         };
     }
 
@@ -205,6 +232,34 @@ public class SwaggerModuleTest {
     @Parameters
     public void testDescriptionResolver(String fieldName, String expectedDescription) {
         new SwaggerModule().applyToConfigBuilder(this.configBuilder);
+
+        TestType testType = new TestType(TestClassForDescription.class);
+        FieldScope field = testType.getMemberField(fieldName);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, String>> captor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withDescriptionResolver(captor.capture());
+        String description = captor.getValue().apply(field);
+        Assert.assertEquals(expectedDescription, description);
+    }
+
+    Object parametersForTestDescriptionResolverWithNoApiModelDescription() {
+        return new Object[][]{
+            {"unannotatedField", null},
+            {"annotatedWithoutValueField", null},
+            {"annotatedWithoutValueGetterField", null},
+            {"annotatedField", "annotation value 1"},
+            {"annotatedGetterField", "annotation value 2"},
+            {"exampleWithEmptyApiModel", null},
+            {"exampleWithApiModelDescription", null},
+            {"exampleWithTwoDescriptions", "property description"},
+            {"exampleWithApiModelTitle", null}
+        };
+    }
+
+    @Test
+    @Parameters
+    public void testDescriptionResolverWithNoApiModelDescription(String fieldName, String expectedDescription) {
+        new SwaggerModule(SwaggerOption.NO_APIMODEL_DESCRIPTION).applyToConfigBuilder(this.configBuilder);
 
         TestType testType = new TestType(TestClassForDescription.class);
         FieldScope field = testType.getMemberField(fieldName);
@@ -322,6 +377,12 @@ public class SwaggerModuleTest {
         Object annotatedField;
         boolean annotatedGetterField;
 
+        ExampleWithEmptyApiModel exampleWithEmptyApiModel;
+        ExampleWithApiModelDescription exampleWithApiModelDescription;
+        @ApiModelProperty(value = "property description")
+        ExampleWithApiModelDescription exampleWithTwoDescriptions;
+        ExampleWithApiModelTitle exampleWithApiModelTitle;
+
         public String getUnannotatedField() {
             return this.unannotatedField;
         }
@@ -342,6 +403,18 @@ public class SwaggerModuleTest {
         @ApiModelProperty(value = "annotation value 2")
         public boolean isAnnotatedGetterField() {
             return this.annotatedGetterField;
+        }
+
+        @ApiModel
+        private class ExampleWithEmptyApiModel {
+        }
+
+        @ApiModel(value = "example title")
+        private class ExampleWithApiModelTitle {
+        }
+
+        @ApiModel(description = "type description")
+        private class ExampleWithApiModelDescription {
         }
     }
 


### PR DESCRIPTION
- Optionally provide a field/method's "title" as per `@ApiModel(value = ...)`
- Allow to ignore the general `@ApiModel(description = ...)` when populating a field/method's "description"